### PR TITLE
Add auth path

### DIFF
--- a/khipu.yml
+++ b/khipu.yml
@@ -98,7 +98,7 @@ components:
         granted:
           type: boolean
     userPermissions:
-      description: a list of permissions for user group
+      description: a list of permissions by user group
       type: object
       additionalProperties:
         type: array

--- a/khipu.yml
+++ b/khipu.yml
@@ -136,10 +136,12 @@ paths:
   /auth:
     description: User authentication
     options:
+      description: Method for passing of CORS policy
       responses:
         '200':
           description: OK
     get:
+      description: Method for getting user's session validating result
       security:
         - JWT: []
       requestBody:
@@ -188,6 +190,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
     post:
+      description: Creating a user's session
       requestBody:
         description: Authentication payload
         required: true
@@ -227,6 +230,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
     patch:
+      description: Updating a user's session token due to security reason
       security:
         - JWT: []
       requestBody:

--- a/khipu.yml
+++ b/khipu.yml
@@ -45,8 +45,10 @@ components:
       type: object
       properties:
         email:
+          description: user's email
           type: string
         pass:
+          description: user's password
           type: string
     session:
       type: object

--- a/khipu.yml
+++ b/khipu.yml
@@ -278,3 +278,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+    delete:
+      description: Delete current user's session
+      security:
+        - JWT: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: '#/components/schemas/confirmation'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'

--- a/khipu.yml
+++ b/khipu.yml
@@ -1,0 +1,104 @@
+openapi: '3.0.3'
+info:
+  title: Khipu API
+  description: Backend API is based on microservices architecture. Each path is processed by one microservice.
+  contact:
+    name: Khipu App
+    url: https://github.com/khipu-app/backend
+    email: dev@khipu.app
+  license:
+    name: GPL-3.0 license
+  version: '0.1.0'
+
+servers:
+  - url: https://api.khipu.app/v1
+
+components:
+  schemas:
+    error:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int64
+        description:
+          type: string
+          maxLength: 4096
+        link:
+          type: string
+          maxLength: 4096
+    credentials:
+      type: object
+      properties:
+        email:
+          type: string
+        pass:
+          type: string
+    session:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          minimum: 1
+        token:
+          type: string
+          maxLength: 1024
+        duration:
+          description: POSIX formatted time (in seconds)
+          type: integer
+          format: int64
+          minimum: 60
+        expired:
+          description: POSIX formatted date and time (in seconds)
+          type: integer
+          format: int64
+          minimum: 0
+
+paths:        
+  /auth:
+    description: User authentication
+    options:
+      responses:
+        '200':
+          description: OK
+    post:
+      requestBody:
+        description: Authentication payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/credentials'
+            
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/session'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'

--- a/khipu.yml
+++ b/khipu.yml
@@ -54,10 +54,12 @@ components:
       type: object
       properties:
         id:
+          description: session ID
           type: integer
           format: int64
           minimum: 1
         token:
+          description: token of user's session
           type: string
           maxLength: 1024
         duration:

--- a/khipu.yml
+++ b/khipu.yml
@@ -21,6 +21,32 @@ components:
       name: Authorization
       description: JWT-token in the format **<token>**
   schemas:
+    confirmation:
+      type: object
+      properties:
+        time:
+          description: POSIX formatted time (in seconds)
+          type: integer
+          format: int64
+        url:
+          description: internal server URL of a request (absolute path)
+          type: string
+          maxLength: 1024
+        ip:
+          description: user client IP address
+          type: string
+        code:
+          description: code of confirmation
+          type: integer
+          format: int64
+        description:
+          description: human readable error description
+          type: string
+          maxLength: 4096
+        link:
+          description: link to documentation with error detailed description
+          type: string
+          maxLength: 4096
     error:
       type: object
       properties:
@@ -178,6 +204,54 @@ paths:
                 $ref: '#/components/schemas/session'
         '400':
           description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    put:
+      security:
+        - JWT: []
+      requestBody:
+        description: Credentials payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/credentials'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                $ref: '#/components/schemas/confirmation'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:

--- a/khipu.yml
+++ b/khipu.yml
@@ -226,7 +226,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
-    put:
+    patch:
       security:
         - JWT: []
       requestBody:

--- a/khipu.yml
+++ b/khipu.yml
@@ -88,7 +88,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/credentials'
-            
       responses:
         '200':
           description: OK

--- a/khipu.yml
+++ b/khipu.yml
@@ -72,6 +72,24 @@ components:
           type: integer
           format: int64
           minimum: 0
+    request:
+      type: object
+      properties:
+        time:
+          description: POSIX formatted time (in seconds)
+          type: integer
+          format: int64
+        url:
+          description: internal server URL of a request (absolute path)
+          type: string
+          maxLength: 1024
+    permission:
+      type: object
+      properties:
+        granted:
+          description: POSIX formatted time (in seconds)
+          type: boolean
+          default: false
 
 paths:        
   /auth:
@@ -80,6 +98,57 @@ paths:
       responses:
         '200':
           description: OK
+    get:
+      requestBody:
+        description: Permission payload
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/request'
+      responses:
+        '200':
+          description: OK
+          headers:
+            Authorization:
+              description: API token from session object
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/permission'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '429':
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+                
     post:
       requestBody:
         description: Authentication payload

--- a/khipu.yml
+++ b/khipu.yml
@@ -90,12 +90,21 @@ components:
           type: string
           maxLength: 1024
     permission:
+      description: a single permission for an operation
       type: object
       properties:
+        operation:
+          type: string
         granted:
-          description: POSIX formatted time (in seconds)
           type: boolean
-          default: false
+    userPermissions:
+      description: a list of permissions for user group
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: object
+          $ref: '#/components/schemas/permission'
 
 paths:        
   /auth:
@@ -108,7 +117,7 @@ paths:
       security:
         - JWT: []
       requestBody:
-        description: Permission payload
+        description: Permissions payload
         required: true
         content:
           application/json:
@@ -120,7 +129,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/permission'
+                type: object
+                $ref: '#/components/schemas/userPermissions'
         '400':
           description: Bad request
           content:

--- a/khipu.yml
+++ b/khipu.yml
@@ -136,12 +136,12 @@ paths:
   /auth:
     description: User authentication
     options:
-      description: Method for passing of CORS policy
+      description: Passing of CORS policy
       responses:
         '200':
           description: OK
     get:
-      description: Method for getting user's session validating result
+      description: Getting user's session validating result
       security:
         - JWT: []
       requestBody:

--- a/khipu.yml
+++ b/khipu.yml
@@ -18,13 +18,27 @@ components:
     error:
       type: object
       properties:
+        time:
+          description: POSIX formatted time (in seconds)
+          type: integer
+          format: int64
+        url:
+          description: internal server URL of a request (absolute path)
+          type: string
+          maxLength: 1024
+        ip:
+          description: user client IP address
+          type: string
         code:
+          description: code of error
           type: integer
           format: int64
         description:
+          description: human readable error description
           type: string
           maxLength: 4096
         link:
+          description: link to documentation with error detailed description
           type: string
           maxLength: 4096
     credentials:

--- a/khipu.yml
+++ b/khipu.yml
@@ -14,6 +14,12 @@ servers:
   - url: https://api.khipu.app/v1
 
 components:
+  securitySchemes:
+    JWT:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: JWT-token in the format **<token>**
   schemas:
     error:
       type: object
@@ -99,6 +105,8 @@ paths:
         '200':
           description: OK
     get:
+      security:
+        - JWT: []
       requestBody:
         description: Permission payload
         required: true
@@ -109,11 +117,6 @@ paths:
       responses:
         '200':
           description: OK
-          headers:
-            Authorization:
-              description: API token from session object
-              schema:
-                type: string
           content:
             application/json:
               schema:
@@ -148,7 +151,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
-                
     post:
       requestBody:
         description: Authentication payload


### PR DESCRIPTION
# Auth

For auth path following schemas, request object and responses are used:

## Schemas

1. **Confirmation** object for process of confirmations at the client side:

```json
{
  "time": "int64",
  "url: string",
  "ip: string",
  "code: int64",
  "description: string",
  "link": "string"
}
```

3. **Error** object for process of errors at the client side:

```json
{
  "time": "int64",
  "url": "string",
  "ip": "string",
  "code":  "int64",
  "description": "string",
  "link" : "string"
}
```

4. **Credentials** object for user authentication with email — `email` and password — `pass`:

```json
{
  "email": "string",
  "pass": "string"
}
```

5. **Session** object with `id` and `token` for using of Khipu's services during `duration` period after each request to the API until expiration time defined in `expired` (date and time in POSIX format in seconds):

```json
{
  "id": "int64",
  "token": "string",
  "duration": "int64",
  "expired": "int64"
}
```

6. **Request** object for getting a request details to return permissions of user action:

```json
{
  "time": "int64",
  "url": "string"
}
```

7. **Permission** object for setup a access level of all operation on an object:

```json
{
  "operation": "string",
  "granted": "boolean"
}
```

8. **userPermissions** object for getting an information of all user permissions by user group:

```json
{
  "groupName1": [
    {
      "operation": "string",
      "granted": "boolean"
    }
  ]
}
```

## Request

### Methods

There are only two methods:

- `OPTIONS` — for passing of CORS policy;
- `GET` — for getting of a user's session validating result;
- `POST` — for creating of a user's session;
- `PATCH` — for updating of a user's session token due to security reason;
- `DELETE` — for deleting of current user's session.

### Request payload

Request could be send only with `POST` method as `credentials` object.

## Response

### Response payloads

Response of the server could be provided only in two formats:

- `session` object;
- `error` object.

## Response codes

All response HTTP codes:

- 200 — OK;
- 400 — Bad request;
- 401 — Unauthorized;
- 403 — Forbidden;
- 429 — Too Many Requests;
- 500 — Internal Server Error.